### PR TITLE
Install specific version of .NET Core for ASP.NET Core project to avoid build break on hosted agent

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-always-auth=true
-registry=__registry__
-__token__

--- a/generators/build/templates/vsts_asp_build.json
+++ b/generators/build/templates/vsts_asp_build.json
@@ -43,6 +43,24 @@
          }
       },
       {
+         "environment": {},
+         "enabled": true,
+         "continueOnError": false,
+         "alwaysRun": false,
+         "displayName": "Use .NET Core SDK 1.0.4",
+         "timeoutInMinutes": 0,
+         "condition": "succeeded()",
+         "task": {
+            "id": "b0ce7256-7898-45d3-9cb5-176b752bfea6",
+            "versionSpec": "0.*",
+            "definitionType": "task"
+         },
+         "inputs": {
+            "packageType": "sdk",
+            "version": "1.0.4"
+         }
+      },
+      {
          "enabled": true,
          "continueOnError": false,
          "alwaysRun": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-team",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-team",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Generates an app with CI/CD in Team Foundation Server or Team Services",
   "main": "./generators/app/index.js",
   "scripts": {


### PR DESCRIPTION
I extended the build template with an additional step to install a matching version of .NET Core SDK on the agent. For the templated ASP.NET Version this would be version 1.0.4. It's currently hard-wired which should be okay for now as the ASP.NET project also has a hardwired version specified. 
Without this task currently the build of ASP.NET Core projects on hosted agents breaks.