### PR TITLE
Migrated the ASP.NET Core build process to use the 2.0 template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ localtest.ps1
 **/.env_vsts
 **/.env_tfs
 integration/temp.js
+**/.DS_Store

--- a/generators/build/templates/vsts_asp_build.json
+++ b/generators/build/templates/vsts_asp_build.json
@@ -1,193 +1,45 @@
 {
    "name": "{{BuildDefName}}",
-   "type": "build",
-   "quality": "definition",
+   "type": 2,
+   "quality": 1,
    "buildNumberFormat": "$(BuildDefinitionName)-$(BuildID)",
-   "queue": {
-      "id": "{{QueueId}}"
-   },
-   "build": [
-      {
-         "enabled": true,
-         "continueOnError": false,
-         "alwaysRun": false,
-         "displayName": "Install bower",
-         "timeoutInMinutes": 0,
-         "task": {
-            "id": "fe47e961-9fa8-4106-8639-368c022d43ad",
-            "versionSpec": "0.*",
-            "definitionType": "task"
-         },
-         "inputs": {
-            "cwd": "",
-            "command": "install",
-            "arguments": "bower --allow-root"
-         }
-      },
-      {
-         "enabled": true,
-         "continueOnError": false,
-         "alwaysRun": false,
-         "displayName": "Run bower",
-         "timeoutInMinutes": 0,
-         "task": {
-            "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-            "versionSpec": "1.*",
-            "definitionType": "task"
-         },
-         "inputs": {
-            "filename": "bower",
-            "arguments": "install --allow-root",
-            "workingFolder": "",
-            "failOnStandardError": "false"
-         }
-      },
-      {
-         "environment": {},
-         "enabled": true,
-         "continueOnError": false,
-         "alwaysRun": false,
-         "displayName": "Use .NET Core SDK 1.0.4",
-         "timeoutInMinutes": 0,
-         "condition": "succeeded()",
-         "task": {
-            "id": "b0ce7256-7898-45d3-9cb5-176b752bfea6",
-            "versionSpec": "0.*",
-            "definitionType": "task"
-         },
-         "inputs": {
-            "packageType": "sdk",
-            "version": "1.0.4"
-         }
-      },
-      {
-         "enabled": true,
-         "continueOnError": false,
-         "alwaysRun": false,
-         "displayName": "Restore",
-         "timeoutInMinutes": 0,
-         "task": {
-            "id": "5541a522-603c-47ad-91fc-a4b1d163081b",
-            "versionSpec": "1.*",
-            "definitionType": "task"
-         },
-         "inputs": {
-            "command": "restore",
-            "publishWebProjects": "true",
-            "projects": "*.sln",
-            "arguments": "--no-cache",
-            "zipAfterPublish": "true"
-         }
-      },
-      {
-         "enabled": true,
-         "continueOnError": false,
-         "alwaysRun": false,
-         "displayName": "Test",
-         "timeoutInMinutes": 0,
-         "task": {
-            "id": "5541a522-603c-47ad-91fc-a4b1d163081b",
-            "versionSpec": "1.*",
-            "definitionType": "task"
-         },
-         "inputs": {
-            "command": "test",
-            "publishWebProjects": "true",
-            "projects": "**/*.Tests.csproj",
-            "arguments": "-l trx",
-            "zipAfterPublish": "true"
-         }
-      },
-      {
-         "enabled": true,
-         "continueOnError": false,
-         "alwaysRun": true,
-         "displayName": "Publish Test Results",
-         "timeoutInMinutes": 0,
-         "task": {
-            "id": "0b0f01ed-7dde-43ff-9cbb-e48954daf9b1",
-            "versionSpec": "2.*",
-            "definitionType": "task"
-         },
-         "inputs": {
-            "testRunner": "VSTest",
-            "testResultsFiles": "**/*.trx",
-            "searchFolder": "$(System.DefaultWorkingDirectory)",
-            "mergeTestResults": "false",
-            "testRunTitle": "Unit",
-            "platform": "$(BuildPlatform)",
-            "configuration": "$(BuildConfiguration)",
-            "publishRunAttachments": "false"
-         }
-      },
-      {
-         "enabled": true,
-         "continueOnError": false,
-         "alwaysRun": false,
-         "displayName": "Publish",
-         "timeoutInMinutes": 0,
-         "task": {
-            "id": "5541a522-603c-47ad-91fc-a4b1d163081b",
-            "versionSpec": "1.*",
-            "definitionType": "task"
-         },
-         "inputs": {
-            "command": "publish",
-            "publishWebProjects": "true",
-            "projects": "",
-            "arguments": "--configuration $(BuildConfiguration) --output $(Build.StagingDirectory)/pub",
-            "zipAfterPublish": "true"
-         }
-      },
-      {
-         "enabled": true,
-         "continueOnError": false,
-         "alwaysRun": false,
-         "displayName": "Copy ARM template files to publish folder",
-         "timeoutInMinutes": 0,
-         "task": {
-            "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
-            "versionSpec": "2.*",
-            "definitionType": "task"
-         },
-         "inputs": {
-            "SourceFolder": "templates/",
-            "Contents": "**/*.json",
-            "TargetFolder": "$(Build.StagingDirectory)/pub/templates/",
-            "CleanTargetFolder": "false",
-            "OverWrite": "true",
-            "flattenFolders": "false"
-         }
-      },
-      {
-         "enabled": true,
-         "continueOnError": false,
-         "alwaysRun": false,
-         "displayName": "Publish Artifact: drop",
-         "timeoutInMinutes": 0,
-         "task": {
-            "id": "2ff763a7-ce83-4e1f-bc89-0ae63477cebe",
-            "versionSpec": "1.*",
-            "definitionType": "task"
-         },
-         "inputs": {
-            "PathtoPublish": "$(Build.StagingDirectory)/pub",
-            "ArtifactName": "drop",
-            "ArtifactType": "Container",
-            "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)"
-         }
-      }
-   ],
+   "queueStatus": 0,
+   "revision": 1,
+   /*"id": 17,
+   "url": "https://<myVSTSName>.visualstudio.com/cee216fc-0a3a-4f15-a4dd-a839e2054da5/_apis/build/Definitions/17",
+   "uri": "vstfs:///Build/Definition/17",
+   "path": "\\",
+   "createdDate": "2017-09-26T14:58:28.140Z",
+   "project": {
+      "id": "cee216fc-0a3a-4f15-a4dd-a839e2054da5",
+      "name": "Demo",
+      "description": "used for demos and deliveries",
+      "url": "https://<myVSTSName>.visualstudio.com/_apis/projects/cee216fc-0a3a-4f15-a4dd-a839e2054da5",
+      "state": "wellFormed",
+      "revision": 74,
+      "visibility": 0
+   }
+   "jobAuthorizationScope": 1,
+   "jobTimeoutInMinutes": 60,
+   "jobCancelTimeoutInMinutes": 5,  
+   */
    "options": [
       {
          "enabled": false,
          "definition": {
-            "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+            "id": "5d58cc01-7c75-450c-be18-a388ddb129ec"
          },
          "inputs": {
-            "multipliers": "[]",
-            "parallel": "false",
-            "continueOnError": "true",
+            "branchFilters": "[\"+refs/heads/*\"]",
+            "additionalFields": "{}"
+         }
+      },
+      {
+         "enabled": false,
+         "definition": {
+            "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+         },
+         "inputs": {
             "additionalFields": "{}"
          }
       },
@@ -196,9 +48,7 @@
          "definition": {
             "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
          },
-         "inputs": {
-            "additionalFields": "{}"
-         }
+         "inputs": {}
       }
    ],
    "triggers": [
@@ -209,7 +59,8 @@
          "pathFilters": [],
          "batchChanges": false,
          "maxConcurrentBuildsPerBranch": 1,
-         "triggerType": "continuousIntegration"
+         "pollingInterval": 0,
+         "triggerType": 2
       }
    ],
    "variables": {
@@ -224,24 +75,18 @@
       "BuildPlatform": {
          "value": "any cpu",
          "allowOverride": true
-      },
-      "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": {
-         "value": "true",
-         "allowOverride": false
-      },
-      "NUGET_XMLDOC_MODE": {
-         "value": "skip",
-         "allowOverride": false
       }
    },
    "repository": {
       "properties": {
          "labelSources": "0",
+         "labelSourcesFormat": "$(build.buildNumber)",
          "reportBuildStatus": "true",
          "fetchDepth": "0",
          "gitLfsSupport": "false",
          "skipSyncSource": "false",
-         "cleanOptions": "0"
+         "cleanOptions": "0",
+         "checkoutNestedSubmodules": "false"
       },
       "type": "TfsGit",
       "name": "{{Project}}",
@@ -249,5 +94,227 @@
       "defaultBranch": "refs/heads/master",
       "clean": "false",
       "checkoutSubmodules": false
+   },
+   "retentionRules": [
+      {
+         "branches": [
+            "+refs/heads/*"
+         ],
+         "artifacts": [],
+         "artifactTypesToDelete": [
+            "FilePath",
+            "SymbolStore"
+         ],
+         "daysToKeep": 10,
+         "minimumToKeep": 1,
+         "deleteBuildRecord": true,
+         "deleteTestResults": true
+      }
+   ],
+   "process": {
+      "phases": [
+         {
+            "dependencies": [],
+            "steps": [
+               {
+                  "environment": {},
+                  "enabled": true,
+                  "continueOnError": false,
+                  "alwaysRun": false,
+                  "displayName": "Use NuGet 4.3.0",
+                  "timeoutInMinutes": 0,
+                  "refName": "NuGetToolInstaller1",
+                  "task": {
+                     "id": "2c65196a-54fd-4a02-9be8-d9d1837b7c5d",
+                     "versionSpec": "0.*",
+                     "definitionType": "task"
+                  },
+                  "inputs": {
+                     "versionSpec": "4.3.0",
+                     "checkLatest": "false"
+                  }
+               },
+               {
+                  "environment": {},
+                  "enabled": true,
+                  "continueOnError": false,
+                  "alwaysRun": false,
+                  "displayName": "NuGet restore",
+                  "timeoutInMinutes": 0,
+                  "refName": "NuGetCommand2",
+                  "task": {
+                     "id": "333b11bd-d341-40d9-afcf-b32d5ce6f23b",
+                     "versionSpec": "2.*",
+                     "definitionType": "task"
+                  },
+                  "inputs": {
+                     "command": "restore",
+                     "solution": "**\\*.sln",
+                     "selectOrConfig": "select",
+                     "feedRestore": "",
+                     "includeNuGetOrg": "true",
+                     "nugetConfigPath": "",
+                     "externalEndpoints": "",
+                     "noCache": "false",
+                     "packagesDirectory": "",
+                     "verbosityRestore": "Detailed",
+                     "searchPatternPush": "$(Build.ArtifactStagingDirectory)/*.nupkg",
+                     "nuGetFeedType": "internal",
+                     "feedPublish": "",
+                     "allowPackageConflicts": "false",
+                     "externalEndpoint": "",
+                     "verbosityPush": "Detailed",
+                     "searchPatternPack": "**/*.csproj",
+                     "configurationToPack": "$(BuildConfiguration)",
+                     "outputDir": "$(Build.ArtifactStagingDirectory)",
+                     "versioningScheme": "off",
+                     "includeReferencedProjects": "false",
+                     "versionEnvVar": "",
+                     "requestedMajorVersion": "1",
+                     "requestedMinorVersion": "0",
+                     "requestedPatchVersion": "0",
+                     "packTimezone": "utc",
+                     "includeSymbols": "false",
+                     "buildProperties": "",
+                     "verbosityPack": "Detailed",
+                     "arguments": ""
+                  }
+               },
+               {
+                  "environment": {},
+                  "enabled": true,
+                  "continueOnError": false,
+                  "alwaysRun": false,
+                  "displayName": "Build solution **\\*.sln",
+                  "timeoutInMinutes": 0,
+                  "refName": "VSBuild3",
+                  "task": {
+                     "id": "71a9a2d3-a98a-4caa-96ab-affca411ecda",
+                     "versionSpec": "1.*",
+                     "definitionType": "task"
+                  },
+                  "inputs": {
+                     "solution": "**\\*.sln",
+                     "vsVersion": "latest",
+                     "msbuildArgs": "/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation=\"$(build.artifactstagingdirectory)\\\\\"",
+                     "platform": "$(BuildPlatform)",
+                     "configuration": "$(BuildConfiguration)",
+                     "clean": "false",
+                     "maximumCpuCount": "false",
+                     "restoreNugetPackages": "false",
+                     "msbuildArchitecture": "x86",
+                     "logProjectEvents": "true",
+                     "createLogFile": "false"
+                  }
+               },
+               {
+                  "environment": {},
+                  "enabled": true,
+                  "continueOnError": false,
+                  "alwaysRun": false,
+                  "displayName": "VsTest - testAssemblies",
+                  "timeoutInMinutes": 0,
+                  "refName": "VSTest4",
+                  "task": {
+                     "id": "ef087383-ee5e-42c7-9a53-ab56c98420f9",
+                     "versionSpec": "2.*",
+                     "definitionType": "task"
+                  },
+                  "inputs": {
+                     "testSelector": "testAssemblies",
+                     "testAssemblyVer2": "**\\$(BuildConfiguration)\\*test*.dll\n!**\\obj\\**",
+                     "testPlan": "",
+                     "testSuite": "",
+                     "testConfiguration": "",
+                     "tcmTestRun": "$(test.RunId)",
+                     "searchFolder": "$(System.DefaultWorkingDirectory)",
+                     "testFiltercriteria": "",
+                     "runOnlyImpactedTests": "False",
+                     "runAllTestsAfterXBuilds": "50",
+                     "uiTests": "false",
+                     "vstestLocationMethod": "version",
+                     "vsTestVersion": "latest",
+                     "vstestLocation": "",
+                     "runSettingsFile": "",
+                     "overrideTestrunParameters": "",
+                     "pathtoCustomTestAdapters": "",
+                     "runInParallel": "False",
+                     "runTestsInIsolation": "False",
+                     "codeCoverageEnabled": "False",
+                     "otherConsoleOptions": "",
+                     "distributionBatchType": "basedOnTestCases",
+                     "batchingBasedOnAgentsOption": "autoBatchSize",
+                     "customBatchSizeValue": "10",
+                     "batchingBasedOnExecutionTimeOption": "autoBatchSize",
+                     "customRunTimePerBatchValue": "60",
+                     "dontDistribute": "False",
+                     "testRunTitle": "",
+                     "platform": "$(BuildPlatform)",
+                     "configuration": "$(BuildConfiguration)",
+                     "publishRunAttachments": "true"
+                  }
+               },
+               {
+                  "environment": {},
+                  "enabled": true,
+                  "continueOnError": true,
+                  "alwaysRun": false,
+                  "displayName": "Publish symbols path: ",
+                  "timeoutInMinutes": 0,
+                  "refName": "PublishSymbols6",
+                  "task": {
+                     "id": "0675668a-7bba-4ccb-901d-5ad6554ca653",
+                     "versionSpec": "1.*",
+                     "definitionType": "task"
+                  },
+                  "inputs": {
+                     "SymbolsPath": "",
+                     "SearchPattern": "**\\bin\\**\\*.pdb",
+                     "SymbolsFolder": "",
+                     "SkipIndexing": "false",
+                     "TreatNotIndexedAsWarning": "false",
+                     "SymbolsMaximumWaitTime": "",
+                     "SymbolsProduct": "",
+                     "SymbolsVersion": "",
+                     "SymbolsArtifactName": "Symbols_$(BuildConfiguration)"
+                  }
+               },
+               {
+                  "environment": {},
+                  "enabled": true,
+                  "continueOnError": false,
+                  "alwaysRun": false,
+                  "displayName": "Publish Artifact: drop",
+                  "timeoutInMinutes": 0,
+                  "refName": "PublishBuildArtifacts7",
+                  "task": {
+                     "id": "2ff763a7-ce83-4e1f-bc89-0ae63477cebe",
+                     "versionSpec": "1.*",
+                     "definitionType": "task"
+                  },
+                  "inputs": {
+                     "PathtoPublish": "$(build.artifactstagingdirectory)",
+                     "ArtifactName": "drop",
+                     "ArtifactType": "Container",
+                     "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)",
+                     "Parallel": "false",
+                     "ParallelCount": "8"
+                  }
+               }
+            ],
+            "variables": {},
+            "name": "Phase 1",
+            "target": {
+               "demands": [],
+               "executionOptions": {
+                  "type": 0
+               },
+               "type": 1
+            },
+            "jobAuthorizationScope": "projectCollection",
+            "jobCancelTimeoutInMinutes": 1
+         }
+      ],
+      "type": 1
    }
 }


### PR DESCRIPTION
As discussed on issue #8, this is the updated version of the template to support 2.0 builds instead of 1.1 which was the previous version. I copied the exact same template format (export and edit) we currently have in VSTS.

Comments and feedback are more than welcome. 