### PR TITLE
Error of missing strict mode

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -50,6 +50,7 @@ function input() {
    // Collect any missing data from the user.
    // This gives me access to the generator in the
    // when callbacks of prompt
+   "use strict";
    let cmdLnInput = this;
 
    return this.prompt([

--- a/generators/app/utility.js
+++ b/generators/app/utility.js
@@ -26,12 +26,14 @@ function isDocker(value) {
 }
 
 function getDockerRegistryServer(server) {
+   "use strict";
    let parts = url.parse(server);
 
    return parts.host;
 }
 
 function getImageNamespace(registryId, endPoint) {
+   "use strict";
    let dockerNamespace = registryId ? registryId.toLowerCase() : null;
 
    if (endPoint && endPoint.authorization && !isDockerHub(endPoint.authorization.parameters.registry)) {
@@ -65,6 +67,7 @@ function reconcileValue(first, second, fallback) {
 function getTargets(answers) {
 
    return new Promise(function (resolve, reject) {
+      "use strict";
       let pat = encodePat(answers.pat);
 
       isTFSGreaterThan2017(answers.tfs, pat, function (e, result) {
@@ -134,6 +137,7 @@ function getTargets(answers) {
 
 function getAppTypes(answers) {
    // Default to languages tha work on all agents
+   "use strict";
    let types = [{
       name: `.NET Core`,
       value: `asp`
@@ -850,6 +854,7 @@ function needsRegistry(answers, cmdLnInput) {
 }
 
 function needsDockerHost(answers, cmdLnInput) {
+   "use strict";
    let isDocker;
    let paasRequiresHost;
 


### PR DESCRIPTION
Hi Donovan,
I faced error of missing strict mode. Something like below:
___________________________________________________________________
/home/soni/net/node_modules/generator-team/generators/app/index.js:53
   let cmdLnInput = this;
   ^^^
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:374:25)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at Object.defineProperty.get [as team:app] (/opt/node/lib/node_modules/yo/node_modules/yeoman-environment/lib/store.js:40:23)
    at Store.get (/opt/node/lib/node_modules/yo/node_modules/yeoman-environment/lib/store.js:64:35)
    at Environment.get (/opt/node/lib/node_modules/yo/node_modules/yeoman-environment/lib/environment.js:262:16)
___________________________________________________________________
I made the necessary changes and found it working. I am running npm on Ubuntu 16.04. Please consider if the change is worth integrating. 
Thank You
Shailesh Yadav