### PR TITLE
Adding NPM command to Install Section of Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ It allows you to deploy to the following platforms:
 - [Docker Toolbox](https://github.com/docker/toolbox/releases)
 
 ## Install
+'npm install yo'
+'npm install generator-team'
 You can read how to use it at [DonovanBrown.com](http://donovanbrown.com/post/yo-Team). 
 
 ## To test


### PR DESCRIPTION
While reviewing the readme on github and the blog post on http://donovanbrown.com/post/yo-Team I was unable to find the command to install yeoman or the team generator and I added both to the Github readme.