### PR TITLE
Fixing markdown. Used wrong ' for code highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ It allows you to deploy to the following platforms:
 - [Docker Toolbox](https://github.com/docker/toolbox/releases)
 
 ## Install
-'npm install yo'
-'npm install generator-team'
+`npm install yo`
+
+`npm install generator-team`
+
 You can read how to use it at [DonovanBrown.com](http://donovanbrown.com/post/yo-Team). 
 
 ## To test


### PR DESCRIPTION
Used single quote ' instead of tick ` for code highlighting. Also put each npm command onto a separate line to make it easier for the reader to understand the commands are separate.